### PR TITLE
trading-lab: ETH/USDT Monthly RB Reversal → 2397

### DIFF
--- a/content/blog/ethusdt-monthly-rb-reversal-2397.md
+++ b/content/blog/ethusdt-monthly-rb-reversal-2397.md
@@ -1,0 +1,234 @@
+---
+title: "ETH/USDT: Місячний RB тримає — бики готують розворот до 2397"
+date: 2026-03-09
+description: "TDA-аналіз ETH/USDT від 1M до H1. Ціна в глибокому дисконті місячного Dealing Range, W1 Strong Low на 1800 тримає. Два плани входу з таргетом на W1 FVG 2397."
+tags: ["ethusdt", "trading", "price-action", "tda", "crypto"]
+---
+
+ETH тримається в зоні місячного RB (Rejection Block) 1748–1965 після 65% падіння від ATH. W1 фрактальний лоу 1800 витримав три тижні тиску — це Strong Low і KL (Key Level). Ціна зараз на 2029, і TDA (Top-Down Analysis) ланцюг від 1M до H1 вказує на бичачий розворот з таргетом W1 FVG (Fair Value Gap) на 2397.
+
+## Narrative
+
+Кожен таймфрейм підтверджує попередній. Ланцюг від 1M до H1 не рветься — рідкість для ведмежого тренду. Саме тому bias 60/40 на користь биків.
+
+```
+BIAS: BULLISH (60% bull / 40% bear)
+PAIR: ETHUSDT
+DATE: 2026-03-09
+
+─── CHAIN ───────────────────────────────────────────────────────────────
+
+1M │ bearish trend  │ price in 1M RB (1748-1965), DR 0.39  → RB = VC zone (MTV)
+W1 │ bearish struct │ fractal low 1800 = KL (3+ weeks)     → VC confirmed
+D1 │ ascending lows │ 2x bullish displacement (+16%, +11%) → VC confirmed
+H4 │ bullish OF     │ ascending from 1916                   → emerging VC
+H1 │ bullish struct │ higher highs/lows from 1916           → VC confirmed
+
+─── CONCLUSION ──────────────────────────────────────────────────────────
+
+Chain intact from 1M to H1. Each TF confirms
+bullish interest at the 1M RB / W1 KL zone.
+Conditional: must hold 1916-1930 floor and break 2199.
+HTF Discount (0.39 on 1M) supports reversal thesis.
+```
+
+Два displaceменти на D1 — 25 лютого (+16%) і 4 березня (+11%) — показують реальну силу покупців. Лоу піднімаються: 1748 → 1800 → 1835 → 1907 → 1916 → 1930. Це класична VC (Volume Confirmation) для W1 KL.
+
+## Structure
+
+Від ATH 4957 ціна впала на 65%. Зараз ми в нижній третині всього діапазону. Ось повна цінова карта з усіма рівнями.
+
+```
+Price ($)
+  │
+4957 ──────── ATH / Monthly DR High
+  │       \
+  │        \  7 months decline (~65%)
+  │
+3403 ──────── W1 Last Fractal High (Jan 12)
+  │
+2919 ──────── W1 DR Equilibrium
+  │
+2519 ──────── 1M DR Equilibrium
+  │
+2397 ════════ W1 FVG TARGET ◎
+  │
+2222 ════════ W1 FVG zone top (TA)
+2199 ──────── D1 Fractal High (Mar 4)
+2148 ════════ W1 FVG zone bottom / D1 old Fractal High
+  │
+2055 ──────── D1 IFVG top (FTA)
+2041 ──────── D1 IFVG bottom
+  │
+2033 ──────── H1 Fractal High
+2029 ◆ PRICE
+1976 ──────── H1 FVG top
+1966 ──────── H1 FVG bottom
+  │
+1965 ════════ 1M RB top / D1 SNR
+1930 ~~~~~~~~ Support floor top
+1916 ~~~~~~~~ H4 Fractal Low / Support floor bottom
+  │
+1870 ──────── D1 FVG top
+1835 ──────── D1 Fractal Low (Feb 28)
+1800 ════════ W1 FRACTAL LOW = KL (POINT A)
+  │
+1748 ════════ 1M RB BOTTOM / INVALIDATION
+
+──── ═══ key level   ─── regular   ~~~ range
+```
+
+Зверніть увагу на щільність рівнів між 2029 і 2222. Це три бар'єри на шляху до таргету: D1 IFVG (Inverted Fair Value Gap) 2041–2055, D1 фрактальний хай 2199 і W1 FVG зона 2148–2222. Кожен із них — TA (Trouble Area), де ціна сповільниться або розвернеться.
+
+## Liquidity Map
+
+Ліквідність розподілена нерівномірно. Зверху три чіткі supply-зони, знизу — глибока demand-структура з шістьма рівнями підтримки.
+
+```
+SUPPLY (resistance)                    DEMAND (support)
+──────────────────                     ────────────────
+
+▼ W1 FVG    2148-2222  W1  MAJOR TA
+▼ D1 IFVG   2041-2055  D1  FTA
+▼ H1 FH     2033       H1  immediate
+                                       ▲ H1 FVG     1966-1976  H1  pullback zone
+                                       ▲ D1 SNR     1930-1965  D1  support floor
+                                       ▲ H4 FL      1916       H4  swing low
+                                       ▲ D1 FVG     1835-1870  D1  deep support
+                                       ▲ D1 FL      1835       D1  fractal low
+                                       ▲ W1 FL      1800       W1  KL (Strong Low)
+                                       ▲ 1M RB      1748-1965  1M  macro demand
+
+──── POI TABLE ──────────────────────────────────────────────────
+
+POI    │ Zone        │ Type           │ TF │ Status
+───────┼─────────────┼────────────────┼────┼──────────────────
+POI-1  │ 1800        │ W1 KL/Strong L │ W1 │ active (Point A)
+POI-2  │ 2397        │ W1 FVG target  │ W1 │ unfilled (Point B)
+POI-3  │ 1916-1930   │ Support floor  │ H4 │ active
+POI-4  │ 2041-2055   │ D1 IFVG (FTA)  │ D1 │ active resistance
+POI-5  │ 2148-2222   │ W1 FVG (TA)    │ W1 │ active resistance
+
+──── KEY OBSERVATIONS ───────────────────────────────────────────
+
+• Path to 2397 has 3 barriers: D1 IFVG 2041-2055, D1 FH 2199, W1 FVG 2148-2222
+• W1 fractal low 1800 = Strong Low (held 3+ weeks after 1748 sweep)
+• Ascending lows: 1748 → 1800 → 1835 → 1907 → 1916 → 1930
+• H1 EQ at 2397 coincides exactly with W1 FVG target
+```
+
+{{< callout type="insight" >}}
+POI-1 (1800) і POI-2 (2397) — це Point A і Point B наративу. Вся торгівля будується навколо руху від A до B. Формула: W1 KL (1800) → D1 VC → W1 FVG (2397).
+{{< /callout >}}
+
+## Trading Plan
+
+Два плани з одним таргетом. Plan A — якщо підлога 1916–1930 тримає. Plan B — якщо ні. Обидва бичачі, різниця тільки в глибині входу і RR (Risk:Reward).
+
+```
+PLAN A — BULL (60%)
+════════════════════
+
+Bias:         Bullish
+Narrative:    W1 KL (1800) → D1 VC (displacements + ascending lows) → W1 FVG (2397)
+Background:   1M RB Discount, W1 Strong Low held, D1 VC confirmed, H4 bullish OF emerging
+Invalidation: Weekly close < $1,748 (1M RB bottom)
+
+┌─ Entry A1 (aggressive) ──────────────────────┐
+│ Type:    VC Entry                              │
+│ Zone:    $1,966–$1,976 (H1 FVG pullback)      │
+│ Confirm: H4 bullish candle above $2,000       │
+│          + pullback respecting H1 FVG         │
+│ SL:      below $1,790 (W1 Strong Low)         │
+│ Target:  $2,397 (W1 FVG)                      │
+│ RR:      ~1:2.3                               │
+└────────────────────────────────────────────────┘
+
+┌─ Entry A2 (conservative) ────────────────────┐
+│ Type:    VC Entry                              │
+│ Zone:    $2,041–$2,055 (D1 IFVG flip)        │
+│ Trigger: D1 close above $2,055 with          │
+│          displacement, pullback to zone       │
+│ SL:      below $1,905 (H4 fractal low)       │
+│ Target:  $2,397 (W1 FVG)                      │
+│ RR:      ~1:2.4 (tactical SL)                │
+└────────────────────────────────────────────────┘
+```
+
+Entry A1 — агресивний вхід на H1 FVG 1966–1976 з підтвердженням на H4. Entry A2 — консервативний, чекаємо фліп D1 IFVG зони 2041–2055. В A2 стоп тактичний — 1905 замість 1790 — щоб дістати RR вище 2.
+
+{{< callout type="insight" >}}
+Два displaceменти на D1 вже не змогли утримати ціну вище 2050. Тому A2 entry вимагає саме D1 close вище 2055 з displacement — без цього підтвердження вхід занадто ризикований.
+{{< /callout >}}
+
+```
+PLAN B — BULL DELAYED (40%)
+════════════════════════════
+
+Bias:         Bullish (deeper retest)
+Narrative:    W1 KL (1800) → D1 FVG retest (1870) → H4 VC → W1 FVG (2397)
+Background:   H4 support 1916-1930 breaks, price retests D1 FVG 1835-1870
+Activation:   H4 close < $1,916 (support floor broken)
+Invalidation: Weekly close < $1,748
+
+┌─ Entry (deep retest) ────────────────────────┐
+│ Type:    VC Entry                              │
+│ Zone:    $1,835–$1,870 (D1 FVG / fractal)    │
+│ Confirm: H4 bullish displacement from zone    │
+│ SL:      below $1,790 (W1 Strong Low)         │
+│ Target:  $2,397 (W1 FVG)                      │
+│ RR:      ~1:5.7                               │
+└────────────────────────────────────────────────┘
+```
+
+Plan B активується тільки при пробої підлоги 1916–1930. RR тут 5.7 — найкращий з усіх варіантів. Стоп той самий — під W1 Strong Low 1790.
+
+```
+──── VISUAL PLAN ────────────────────────────────────────────────
+
+$2,397 ════ TARGET ◎ (W1 FVG)
+  │
+$2,222 ════ W1 FVG zone top (TA)
+$2,199 ──── D1 Fractal High (liquidity)
+$2,148 ════ W1 FVG zone bottom (TA)
+  │
+$2,055 ──── Plan A2 entry (D1 IFVG)
+$2,041 ──── Plan A2 entry bottom
+  │
+$2,029 ◆◆◆ PRICE ◆◆◆
+  │
+$1,976 ──── Plan A1 entry (H1 FVG)
+$1,966 ──── Plan A1 entry bottom
+  │
+$1,930 ~~~~ Support floor
+$1,916 ~~~~ H4 Fractal Low
+  │          ↓ break below = Plan B activates
+$1,870 ──── Plan B entry (D1 FVG)
+$1,835 ──── Plan B entry bottom
+  │
+$1,800 ════ W1 Strong Low / KL
+$1,790 ════ SL (Plans A & B)
+  │
+$1,748 ════ FULL INVALIDATION ✗
+
+  PLAN A (Bull)              PLAN B (Bull delayed)
+  ────────────               ─────────────────────
+  A1: 1966-1976 long         Trigger: <1916
+  A2: 2041-2055 long         Entry: 1835-1870
+  SL: 1790                   SL: 1790
+  Target: 2397               Target: 2397
+  RR: 2.3 / 2.4              RR: 5.7
+  Inv: W1 close <1748        Inv: W1 close <1748
+```
+
+{{< callout type="insight" >}}
+Гейт між планами — рівень 1916. Поки ціна вище нього, працює Plan A. H4 close нижче 1916 перемикає на Plan B. Повна інвалідація обох планів — тижневий close нижче 1748.
+{{< /callout >}}
+
+## Що далі
+
+Слідкую за трьома речами. Перше — чи тримає підлога 1916–1930 на H4: це визначає, який план активний. Друге — реакція ціни на D1 IFVG 2041–2055: flip цієї зони відкриє дорогу до W1 FVG. Третє — тижнева свічка: close вище 2055 підтвердить бичачий bias, close нижче 1748 — повна інвалідація.
+
+---
+
+*Це не фінансова порада. Торгівля на фінансових ринках пов'язана з ризиком.*


### PR DESCRIPTION
## Summary

- TDA analysis ETHUSDT from 1M to H1 — bullish bias (60/40)
- Price in monthly RB zone (1748–1965), W1 Strong Low at 1800 held 3+ weeks
- Two bullish plans targeting W1 FVG at 2397
- Plan A: entry at H1 FVG 1966–1976 or D1 IFVG 2041–2055 (RR 2.3–2.4)
- Plan B: deep retest at D1 FVG 1835–1870 (RR 5.7)
- Invalidation: weekly close below 1748

Tracking issue: https://github.com/WhiteTRD/whitetrd-blog/issues/28

## Test plan

- [ ] Verify Hugo builds without errors
- [ ] Check all code blocks render correctly
- [ ] Verify callout shortcodes work
- [ ] Review price levels match analysis data

🤖 Generated with [Claude Code](https://claude.com/claude-code)