### PR TITLE
trading-lab: ETH/USDT W1 Fractal KL reversal — target 2395

### DIFF
--- a/content/blog/ethusdt-w1-fractal-reversal-2395.md
+++ b/content/blog/ethusdt-w1-fractal-reversal-2395.md
@@ -1,0 +1,254 @@
+---
+title: "ETH/USDT: Розворот від W1 Fractal KL — ціль 2395"
+date: 2026-03-09
+description: "Аналіз ETH/USDT: bullish розворот від W1 Fractal KL 1800 в межах 1M RB. TDA від 1M до H1, плани входу з R:R до 7.2."
+tags: ["ETH", "USDT", "crypto", "TDA", "swing", "FVG", "reversal"]
+---
+
+## Hook
+
+Ethereum п'ять тижнів стоїть у range 1800–2199. Я аналізую цю консолідацію через TDA (Top-Down Analysis) від 1M до H1, щоб зрозуміти — це накопичення перед рухом чи розподіл перед зливом. Ціна сидить у 1M RB (Rejection Block) і давить на W1 FVG (Fair Value Gap) зверху — момент для рішення.
+
+---
+
+## Narrative: TDA Chain
+
+Структура аналізу — від старшого TF до молодшого. Кожен рівень підтверджує або спростовує bias. Я будую causal chain: причина на 1M, підтвердження на D1, вхід на H4/H1.
+
+```
+narrative.txt — TDA Chain Table
+═══════════════════════════════════════════════════════════════
+  TF   │  Structure         │  Key Level          │  Role
+═══════════════════════════════════════════════════════════════
+  1M   │  Bearish (decel.)  │  RB 1748-1965       │  Discount zone
+       │                    │  EQ 2519            │  Macro reference
+───────┼────────────────────┼─────────────────────┼───────────
+  W1   │  Base formation    │  KL 1800 (Fractal)  │  Idea anchor
+       │                    │  FVG 2270-2397      │  Target
+       │                    │  Last FH 3403       │  Macro high
+───────┼────────────────────┼─────────────────────┼───────────
+  D1   │  Structural shift  │  FVG 1870-1975      │  Demand
+       │                    │  Strong Low 1800    │  Invalidation
+       │                    │  Strong High 2199   │  T1
+───────┼────────────────────┼─────────────────────┼───────────
+  H4   │  OF shift (1916)   │  FVG 1963-1974      │  Entry zone
+       │                    │  Strong Low 1916    │  Local SL
+       │                    │  FTA 2055-2083      │  First resist.
+───────┼────────────────────┼─────────────────────┼───────────
+  H1   │  Bullish OF        │  Last FH 2022       │  Momentum
+       │                    │  Last FL 1981       │  Micro support
+═══════════════════════════════════════════════════════════════
+```
+
+На 1M ціна 2024 торгується нижче EQ (2519) — ми в discount. Макро-тренд bearish, але деселерація очевидна: RB 1748–1965 вже swept fractal low. Це не падіння — це уповільнення.
+
+W1 сформував base на 1800 після sweep. D1 підтвердив structural shift серією HH (2148 → 2199) і HL (1800 → 1835 → 1907 → 1916). H4 зламав FH 1980 і побудував OF (Order Flow) shift від 1916.
+
+{{< callout type="insight" >}}
+Causal chain: 1M Discount + RB → W1 Fractal KL 1800 → D1 VC (structural shift) → H4 OF shift → H1 bullish refinement. Кожен TF підтверджує попередній.
+{{< /callout >}}
+
+---
+
+## Structure: Вертикальна цінова шкала
+
+Ось як виглядає цінова карта від 1M до H1. Я розмістив усі ключові рівні на одній шкалі, щоб бачити confluence зон.
+
+```
+structure.txt — Vertical Price Scale
+
+  3403 ════════════════════════════════  W1 Last FH
+         │
+         │         (macro gap)
+         │
+  2519 ────────────────────────────────  1M EQ
+         │
+  2395 ◎ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  W1 FVG top — T2
+  2270   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  W1 FVG bottom
+         │
+  2199 ════════════════════════════════  D1 Strong High — T1
+         │
+  2148 ────────────────────────────────  D1 prev HH
+         │
+  2083 ────────────────────────────────  H4 FTA top
+  2055 ────────────────────────────────  H4 FTA / D1 SNR
+         │
+  2022 ────────────────────────────────  H1 Last FH
+         │
+  1992 ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈  H1 IDM
+  1981 ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈  H1 IDM / Last FL
+         │
+  1975 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  H4/H1 FVG top
+  1963 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  H4/H1 FVG bottom
+         │                                ◆ PRIMARY ENTRY
+  1937 ────────────────────────────────  H4 RB top
+  1916 ════════════════════════════════  H4 Strong Low — SL zone
+         │
+  1907 ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈  D1 prev HL
+  1870 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  D1 FVG bottom
+         │                                ◆ PLAN B ENTRY
+  1835 ────────────────────────────────  D1 prev HL
+         │
+  1800 ════════════════════════════════  D1 Strong Low / W1 KL
+  1748 ════════════════════════════════  1M RB bottom
+         │
+  1385 ────────────────────────────────  1M FL (last resort)
+```
+
+Зверніть увагу на зону 1963–1975. Тут confluence H4 FVG і H1 FVG — це мій primary entry. Нижче — H4 Strong Low 1916, який тримає весь bullish сценарій локально.
+
+Вище — перша перешкода на 2055–2083 (H4 FTA / MB (Mitigation Block)). Пробій цієї зони відкриває шлях до D1 Strong High 2199 і далі на W1 FVG 2270–2397.
+
+{{< chart src="/charts/ethusdt-w1-fractal-reversal-2395/d1.html" >}}
+
+---
+
+## Liquidity Map
+
+Я розділяю ліквідність на чотири категорії: MTV (Most Traded Volume), LTV (Low Traded Volume), LIQ (Liquidity), TA (Trouble Area). Це дає повну картину — де гроші, де пастки, де цілі.
+
+```
+liquidity.txt — Supply/Demand Map + POI Table
+═══════════════════════════════════════════════════════════════
+
+  ▲ SUPPLY / RESISTANCE
+  │
+  │  2270-2397   W1 FVG (target supply)          ◎ POINT B
+  │  2199        D1 Strong High                  ◎ T1
+  │  2127-2199   D1 TA zone
+  │  2055-2083   H4 FTA / D1 SNR                 ──── resist.
+  │  2041-2055   D1 IFVG (Inverse FVG)           ~~~~ mixed
+  │
+  │─────────────── ◆ CURRENT PRICE ~2024 ──────────────────
+  │
+  │  1963-1975   H4/H1 FVG                       ▓▓ demand
+  │  1916-1937   H4 RB + Strong Low              ▓▓ demand
+  │  1870-1975   D1 FVG (wide demand)            ▓▓ demand
+  │  1800-1856   D1 RB                           ▓▓ demand
+  │  1748-1965   1M RB                           ════ KL
+  │
+  ▼ DEMAND / SUPPORT
+
+═══════════════════════════════════════════════════════════════
+
+  POI Table (Ranked by Priority)
+═══════════════════════════════════════════════════════════════
+  #  │  Price        │  Type                │  Function
+═══════════════════════════════════════════════════════════════
+  1  │  1800         │  D1 SL + 1M RB + KL  │  INVALIDATION
+  2  │  1916-1937    │  H4 RB + SL          │  Local SL
+  3  │  1963-1975    │  H4/H1 FVG           │  PRIMARY ENTRY
+  4  │  2055-2083    │  H4 FTA/MB           │  First resistance
+  5  │  2270-2397    │  W1 FVG              │  TARGET (Point B)
+═══════════════════════════════════════════════════════════════
+```
+
+POI #1 (1800) — лінія життя всього аналізу. Закриття D1 нижче — повна інвалідація. POI #3 (1963–1975) — зона, де я чекаю реакцію. Це не просто рівень — це confluence H4 і H1 FVG в межах ширшого D1 FVG (1870–1975).
+
+POI #4 (2055–2083) буде першим тестом для покупців. H4 FTA тут виступає як Mitigation Block — ціна може затриматись. Я закладаю це у план як зону часткового фіксування або trail stop.
+
+{{< callout type="insight" >}}
+HRL (High-Resistance Liquidity) на 1800 — це не просто Strong Low. Це 1M RB + W1 fractal sweep + D1 VC anchor. Тричі підтверджений рівень. Поки він тримає — bias bullish.
+{{< /callout >}}
+
+---
+
+## Plan
+
+Два сценарії. Plan A — основний, з entry на H4 FVG. Plan B — якщо ринок захоче глибший sweep перед розворотом. Обидва ведуть до однієї цілі — W1 FVG 2395.
+
+```
+plan.txt — Plan A: Bullish (Primary)
+═══════════════════════════════════════════════════════════════
+
+  Bias: BULLISH
+  Narrative: W1 KL (1800) → D1 VC → W1 FVG target (2395)
+  Entry type: VC (Volume Confirmation) Entry
+  Trigger: H1 bullish close > 1990 after FVG touch
+
+                    ◎ T2: 2395 (W1 FVG)         R:R = 7.2
+                    │
+                    │        ▲
+                    │        ▲
+                    │        ▲
+                    ◎ T1: 2199 (D1 Strong High)  R:R = 3.9
+                    │        ▲
+  ──── 2083 ───────│──── H4 FTA ──── (resistance)
+  ──── 2055 ───────│────────────────
+                    │        ▲
+  ──── 2022 ───────│──── H1 FH ────
+                    │        ▲
+                    │
+     ┌──────────────────────────────┐
+     │  ENTRY ZONE: 1963-1975      │
+     │  H4/H1 FVG confluence       │
+     │  ◆ Wait for H1 VC           │
+     └──────────────────────────────┘
+                    │
+     ┌──────────────────────────────┐
+     │  SL: 1910                   │
+     │  Below H4 SL 1916           │
+     │  Risk: ~65 pts              │
+     └──────────────────────────────┘
+
+  Invalidation:
+    Local  → H4 close < 1916
+    Full   → D1 close < 1800
+
+═══════════════════════════════════════════════════════════════
+
+plan.txt — Plan B: Deeper Accumulation
+═══════════════════════════════════════════════════════════════
+
+  Bias: BEARISH short-term → BULLISH from deeper level
+  Narrative: Sweep 1835-1870 → D1 rejection → H4 VC
+  Trigger: H4 bullish displacement from D1 FVG
+
+                    ◎ T2: 2395 (W1 FVG)         R:R = 7.0
+                    │
+                    │        ▲
+                    │        ▲
+                    ◎ T1: 2199 (D1 Strong High)  R:R = 4.4
+                    │        ▲
+                    │        ▲
+  ──── 1975 ───────│──── H4 FVG ────
+  ──── 1916 ═══════│════ H4 SL ════ (broken in this scenario)
+                    │        ▲
+     ┌──────────────────────────────┐
+     │  ENTRY ZONE: 1835-1870      │
+     │  D1 FVG bottom              │
+     │  ◆ Wait for H4 VC           │
+     └──────────────────────────────┘
+                    │
+     ┌──────────────────────────────┐
+     │  SL: 1790                   │
+     │  Below D1 SL 1800           │
+     │  Risk: ~65 pts              │
+     └──────────────────────────────┘
+
+  Invalidation:
+    Full   → D1 close < 1800
+    Next   → 1385 (1M FL)
+
+═══════════════════════════════════════════════════════════════
+```
+
+Plan A дає R:R 3.9 до T1 і 7.2 до T2. Я чекаю pullback в зону 1963–1975 і H1 VC — bullish close вище 1990. Це підтвердить, що FVG працює як demand. Стоп під 1916 з буфером — на 1910.
+
+Plan B активується, якщо H4 Strong Low 1916 не тримає. Тоді я чекаю sweep зони 1835–1870 (дно D1 FVG) і шукаю H4 displacement. Risk:Reward навіть кращий — 4.4R і 7.0R, але ймовірність нижча, бо пробій 1916 ламає H4 OF.
+
+{{< chart src="/charts/ethusdt-w1-fractal-reversal-2395/h4.html" >}}
+
+{{< callout type="insight" >}}
+Обидва плани мають одну ціль (2395) і одну повну інвалідацію (D1 close < 1800). Різниця — рівень входу і тригер. Plan A агресивніший, Plan B консервативніший. Я віддаю пріоритет Plan A, поки 1916 тримає.
+{{< /callout >}}
+
+---
+
+## What's Next
+
+Я чекаю понеділкового відкриття і першої H4 свічки. Якщо ціна повертається до 1963–1975 без імпульсного пробою — готую VC entry за Plan A. Якщо тижнева свічка закривається вище 2083 без pullback — entry пропущений, чекаю наступну можливість.
+
+---
+
+*Disclaimer: Це особистий аналіз, а не фінансова порада. Торгівля криптовалютами пов'язана з високим ризиком втрати капіталу. Кожен трейдер несе повну відповідальність за свої рішення. Завжди використовуйте ризик-менеджмент і не торгуйте коштами, які не можете дозволити собі втратити.*

--- a/layouts/shortcodes/chart.html
+++ b/layouts/shortcodes/chart.html
@@ -1,0 +1,6 @@
+<iframe
+  src="{{ .Get "src" }}"
+  style="width:100%;height:500px;border:1px solid #e5e7eb;border-radius:8px;"
+  loading="lazy"
+  sandbox="allow-scripts">
+</iframe>

--- a/static/charts/ethusdt-w1-fractal-reversal-2395/d1.html
+++ b/static/charts/ethusdt-w1-fractal-reversal-2395/d1.html
@@ -1,0 +1,371 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ETHUSDT · D1</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  @media (prefers-color-scheme: dark) { body { background: #0a0a0a; } }
+  @media (prefers-color-scheme: light) { body { background: #fafafa; } }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<script type="text/babel">
+const {useState, useEffect} = React;
+
+
+const DARK = {
+  bg: "#0a0a0a", bull: "#d4d4d4", bear: "#737373", wick: "#888",
+  zone: "#555", zoneFill: "#ffffff", accent: "#999", dim: "#333",
+  dimmer: "#1a1a1a", text: "#888", muted: "#555", price: "#d4d4d4",
+};
+const LIGHT = {
+  bg: "#fafafa", bull: "#1a1a1a", bear: "#999999", wick: "#888",
+  zone: "#aaaaaa", zoneFill: "#000000", accent: "#666666", dim: "#d0d0d0",
+  dimmer: "#e8e8e8", text: "#888888", muted: "#aaaaaa", price: "#1a1a1a",
+};
+
+function useTheme() {
+  const [dark, setDark] = useState(
+    () => typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e) => setDark(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return dark ? DARK : LIGHT;
+}
+
+const mono = { fontFamily: "'SF Mono','Fira Code','Consolas',monospace" };
+
+function Chart({ candles, zones, levels, fractals, title, mode = "candles", width = 620, height = 320 }) {
+  const S = useTheme();
+  const p = { t: 24, b: 28, l: 48, r: 74 };
+  const cW = width - p.l - p.r;
+  const cH = height - p.t - p.b;
+  if (!candles || candles.length === 0) return null;
+  const allP = candles.flat();
+  const dataHi = Math.max(...allP);
+  const dataLo = Math.min(...allP);
+  const margin = (dataHi - dataLo) * 0.08;
+  const hi = dataHi + margin;
+  const lo = dataLo - margin;
+  const y = (v) => p.t + (1 - (v - lo) / (hi - lo)) * cH;
+  const x = (i) => p.l + (i + 0.5) / candles.length * cW;
+  const bw = Math.max(1.5, Math.min(6, cW / candles.length * 0.5));
+  const range = hi - lo;
+  const rawStep = range / 6;
+  const mag = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  const steps = [1, 2, 5, 10];
+  const step = steps.find(s => s * mag >= rawStep) * mag;
+  const gridPrices = [];
+  for (let pr = Math.ceil(lo / step) * step; pr <= hi; pr += step) gridPrices.push(pr);
+
+  return (
+    <svg width={width} height={height} style={{ display: "block", borderRadius: 6 }}>
+      <rect width={width} height={height} fill={S.bg} rx={6} />
+      {title && <text x={p.l + 2} y={14} fill={S.muted} fontSize={9} {...mono}>{title}</text>}
+      {gridPrices.map((pr, i) => (
+        <g key={`g${i}`}>
+          <line x1={p.l} y1={y(pr)} x2={width - p.r} y2={y(pr)} stroke={S.dimmer} strokeWidth={0.5} />
+          <text x={p.l - 6} y={y(pr) + 3} fill={S.muted} fontSize={7} textAnchor="end" {...mono}>{pr}</text>
+        </g>
+      ))}
+      {(zones || []).map((z, zi) => {
+        const ox1 = x(z.originStart) - bw;
+        const ox2 = x(z.originEnd) + bw;
+        const projX = width - p.r;
+        const zH = Math.max(2, y(z.bot) - y(z.top));
+        return (
+          <g key={`z${zi}`}>
+            <rect x={ox1} y={y(z.top)} width={ox2 - ox1} height={zH} fill={S.zoneFill} opacity={0.06} rx={1} />
+            <rect x={ox2} y={y(z.top)} width={projX - ox2} height={zH} fill={S.zoneFill} opacity={0.025} />
+            <line x1={ox1} y1={y(z.top)} x2={ox2} y2={y(z.top)} stroke={S.zone} strokeWidth={0.8} opacity={0.5} />
+            <line x1={ox1} y1={y(z.bot)} x2={ox2} y2={y(z.bot)} stroke={S.zone} strokeWidth={0.8} opacity={0.5} />
+            <line x1={ox2} y1={y(z.top)} x2={projX} y2={y(z.top)} stroke={S.zone} strokeWidth={0.5} opacity={0.2} strokeDasharray="3,4" />
+            <line x1={ox2} y1={y(z.bot)} x2={projX} y2={y(z.bot)} stroke={S.zone} strokeWidth={0.5} opacity={0.2} strokeDasharray="3,4" />
+            <line x1={ox1 - 2} y1={y(z.top)} x2={ox1 - 2} y2={y(z.bot)} stroke={S.accent} strokeWidth={1} opacity={0.35} />
+            <text x={projX + 4} y={y(z.top) + 3} fill={S.accent} fontSize={7} {...mono} opacity={0.6}>{z.label}</text>
+            {z.note && <text x={projX + 4} y={y(z.top) + 12} fill={S.muted} fontSize={6} {...mono} opacity={0.4}>{z.note}</text>}
+            <text x={projX + 4} y={y(z.bot) - 2} fill={S.muted} fontSize={6} {...mono} opacity={0.4}>{z.top}–{z.bot}</text>
+          </g>
+        );
+      })}
+      {(levels || []).map((l, i) => (
+        <g key={`l${i}`}>
+          <line x1={p.l} y1={y(l.val)} x2={width - p.r} y2={y(l.val)} stroke={S.zone} strokeWidth={0.4} opacity={0.2} strokeDasharray={l.dash ? "2,4" : "none"} />
+          <text x={width - p.r + 4} y={y(l.val) + 3} fill={S.muted} fontSize={7} {...mono} opacity={0.4}>{l.label}</text>
+        </g>
+      ))}
+      {mode === "candles" ? (
+        candles.map(([o, h, l, c], i) => {
+          const bull = c >= o;
+          const cx = x(i);
+          return (
+            <g key={`c${i}`}>
+              <line x1={cx} y1={y(h)} x2={cx} y2={y(l)} stroke={S.wick} strokeWidth={0.6} opacity={0.5} />
+              <rect x={cx - bw / 2} y={y(Math.max(o, c))} width={bw} height={Math.max(0.5, Math.abs(y(o) - y(c)))} fill={bull ? S.bg : S.bear} stroke={bull ? S.bull : S.bear} strokeWidth={0.7} opacity={bull ? 0.8 : 0.6} />
+            </g>
+          );
+        })
+      ) : (
+        <polyline points={candles.map(([,,, c], i) => `${x(i)},${y(c)}`).join(" ")} fill="none" stroke={S.price} strokeWidth={1} opacity={0.6} strokeLinejoin="round" />
+      )}
+      {(fractals || []).map((f, i) => {
+        const cx = x(f.idx);
+        const isHigh = f.type === "high";
+        const cy = y(f.price) + (isHigh ? -8 : 10);
+        return (
+          <g key={`f${i}`}>
+            <text x={cx} y={cy} fill={S.accent} fontSize={7} textAnchor="middle" {...mono} opacity={0.5}>{isHigh ? "▽" : "△"}</text>
+            <text x={cx} y={cy + (isHigh ? -7 : 9)} fill={S.muted} fontSize={6} textAnchor="middle" {...mono} opacity={0.35}>{f.price}</text>
+          </g>
+        );
+      })}
+      {(() => {
+        const last = candles[candles.length - 1][3];
+        return (
+          <g>
+            <line x1={p.l} y1={y(last)} x2={width - p.r} y2={y(last)} stroke={S.price} strokeWidth={0.5} strokeDasharray="2,3" opacity={0.2} />
+            <rect x={width - p.r - 1} y={y(last) - 7} width={34} height={14} fill={S.price} rx={2} opacity={0.85} />
+            <text x={width - p.r + 16} y={y(last) + 3} fill={S.bg} fontSize={7} textAnchor="middle" fontWeight="bold" {...mono}>{last}</text>
+          </g>
+        );
+      })()}
+    </svg>
+  );
+}
+
+
+// DATA SECTION
+const TITLE = "ETHUSDT · D1";
+const candles = [
+  [
+    1992,
+    2039,
+    1924,
+    1956
+  ],
+  [
+    1956,
+    1988,
+    1907,
+    1949
+  ],
+  [
+    1949,
+    1981,
+    1923,
+    1969
+  ],
+  [
+    1969,
+    1996,
+    1956,
+    1973
+  ],
+  [
+    1973,
+    1983,
+    1935,
+    1958
+  ],
+  [
+    1958,
+    1958,
+    1837,
+    1856
+  ],
+  [
+    1856,
+    1870,
+    1800,
+    1852
+  ],
+  [
+    1852,
+    2148,
+    1847,
+    2057
+  ],
+  [
+    2057,
+    2083,
+    1975,
+    2028
+  ],
+  [
+    2028,
+    2064,
+    1887,
+    1930
+  ],
+  [
+    1930,
+    1985,
+    1835,
+    1965
+  ],
+  [
+    1965,
+    2055,
+    1907,
+    1940
+  ],
+  [
+    1940,
+    2090,
+    1920,
+    2027
+  ],
+  [
+    2027,
+    2041,
+    1930,
+    1983
+  ],
+  [
+    1983,
+    2199,
+    1945,
+    2127
+  ],
+  [
+    2127,
+    2164,
+    2055,
+    2073
+  ],
+  [
+    2073,
+    2093,
+    1956,
+    1979
+  ],
+  [
+    1979,
+    1996,
+    1948,
+    1970
+  ],
+  [
+    1970,
+    1980,
+    1916,
+    1937
+  ],
+  [
+    1937,
+    2039,
+    1930,
+    2012
+  ]
+];
+const zones = [
+  {
+    "originStart": 6,
+    "originEnd": 8,
+    "top": 1975,
+    "bot": 1870,
+    "label": "D1 FVG",
+    "note": "bull displacement"
+  },
+  {
+    "originStart": 11,
+    "originEnd": 13,
+    "top": 2055,
+    "bot": 2041,
+    "label": "D1 IFVG",
+    "note": "inefficiency"
+  }
+];
+const levels = [
+  {
+    "val": 2199,
+    "label": "D1 Strong High",
+    "dash": false
+  },
+  {
+    "val": 1800,
+    "label": "W1 KL / D1 SL",
+    "dash": false
+  },
+  {
+    "val": 2395,
+    "label": "W1 FVG target",
+    "dash": true
+  },
+  {
+    "val": 2519,
+    "label": "1M EQ",
+    "dash": true
+  }
+];
+const fractals = [
+  {
+    "idx": 7,
+    "type": "high",
+    "price": 2148
+  },
+  {
+    "idx": 14,
+    "type": "high",
+    "price": 2199
+  },
+  {
+    "idx": 6,
+    "type": "low",
+    "price": 1800
+  },
+  {
+    "idx": 7,
+    "type": "low",
+    "price": 1847
+  },
+  {
+    "idx": 10,
+    "type": "low",
+    "price": 1835
+  },
+  {
+    "idx": 9,
+    "type": "low",
+    "price": 1907
+  }
+];
+
+// APP
+function App() {
+  const [mode, setMode] = useState("candles");
+  const S = useTheme();
+  return (
+    <div style={{ background: S.bg, minHeight: "100vh", padding: "24px 16px", ...mono, color: S.price }}>
+      <div style={{ maxWidth: 660, margin: "0 auto" }}>
+        <div style={{ display: "flex", gap: 4, marginBottom: 12 }}>
+          {["candles", "line"].map(m => (
+            <button key={m} onClick={() => setMode(m)} style={{
+              ...mono, fontSize: 10, padding: "4px 16px",
+              background: mode === m ? S.dimmer : "transparent",
+              color: mode === m ? S.price : S.muted,
+              border: `1px solid ${mode === m ? S.dim : S.dimmer}`,
+              borderRadius: 4, cursor: "pointer",
+            }}>{m}</button>
+          ))}
+        </div>
+        <Chart candles={candles} zones={zones} levels={levels} fractals={fractals} title={TITLE} mode={mode} />
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/static/charts/ethusdt-w1-fractal-reversal-2395/h4.html
+++ b/static/charts/ethusdt-w1-fractal-reversal-2395/h4.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ETHUSDT · H4</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  @media (prefers-color-scheme: dark) { body { background: #0a0a0a; } }
+  @media (prefers-color-scheme: light) { body { background: #fafafa; } }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<script type="text/babel">
+const {useState, useEffect} = React;
+
+
+const DARK = {
+  bg: "#0a0a0a", bull: "#d4d4d4", bear: "#737373", wick: "#888",
+  zone: "#555", zoneFill: "#ffffff", accent: "#999", dim: "#333",
+  dimmer: "#1a1a1a", text: "#888", muted: "#555", price: "#d4d4d4",
+};
+const LIGHT = {
+  bg: "#fafafa", bull: "#1a1a1a", bear: "#999999", wick: "#888",
+  zone: "#aaaaaa", zoneFill: "#000000", accent: "#666666", dim: "#d0d0d0",
+  dimmer: "#e8e8e8", text: "#888888", muted: "#aaaaaa", price: "#1a1a1a",
+};
+
+function useTheme() {
+  const [dark, setDark] = useState(
+    () => typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e) => setDark(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return dark ? DARK : LIGHT;
+}
+
+const mono = { fontFamily: "'SF Mono','Fira Code','Consolas',monospace" };
+
+function Chart({ candles, zones, levels, fractals, title, mode = "candles", width = 620, height = 320 }) {
+  const S = useTheme();
+  const p = { t: 24, b: 28, l: 48, r: 74 };
+  const cW = width - p.l - p.r;
+  const cH = height - p.t - p.b;
+  if (!candles || candles.length === 0) return null;
+  const allP = candles.flat();
+  const dataHi = Math.max(...allP);
+  const dataLo = Math.min(...allP);
+  const margin = (dataHi - dataLo) * 0.08;
+  const hi = dataHi + margin;
+  const lo = dataLo - margin;
+  const y = (v) => p.t + (1 - (v - lo) / (hi - lo)) * cH;
+  const x = (i) => p.l + (i + 0.5) / candles.length * cW;
+  const bw = Math.max(1.5, Math.min(6, cW / candles.length * 0.5));
+  const range = hi - lo;
+  const rawStep = range / 6;
+  const mag = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  const steps = [1, 2, 5, 10];
+  const step = steps.find(s => s * mag >= rawStep) * mag;
+  const gridPrices = [];
+  for (let pr = Math.ceil(lo / step) * step; pr <= hi; pr += step) gridPrices.push(pr);
+
+  return (
+    <svg width={width} height={height} style={{ display: "block", borderRadius: 6 }}>
+      <rect width={width} height={height} fill={S.bg} rx={6} />
+      {title && <text x={p.l + 2} y={14} fill={S.muted} fontSize={9} {...mono}>{title}</text>}
+      {gridPrices.map((pr, i) => (
+        <g key={`g${i}`}>
+          <line x1={p.l} y1={y(pr)} x2={width - p.r} y2={y(pr)} stroke={S.dimmer} strokeWidth={0.5} />
+          <text x={p.l - 6} y={y(pr) + 3} fill={S.muted} fontSize={7} textAnchor="end" {...mono}>{pr}</text>
+        </g>
+      ))}
+      {(zones || []).map((z, zi) => {
+        const ox1 = x(z.originStart) - bw;
+        const ox2 = x(z.originEnd) + bw;
+        const projX = width - p.r;
+        const zH = Math.max(2, y(z.bot) - y(z.top));
+        return (
+          <g key={`z${zi}`}>
+            <rect x={ox1} y={y(z.top)} width={ox2 - ox1} height={zH} fill={S.zoneFill} opacity={0.06} rx={1} />
+            <rect x={ox2} y={y(z.top)} width={projX - ox2} height={zH} fill={S.zoneFill} opacity={0.025} />
+            <line x1={ox1} y1={y(z.top)} x2={ox2} y2={y(z.top)} stroke={S.zone} strokeWidth={0.8} opacity={0.5} />
+            <line x1={ox1} y1={y(z.bot)} x2={ox2} y2={y(z.bot)} stroke={S.zone} strokeWidth={0.8} opacity={0.5} />
+            <line x1={ox2} y1={y(z.top)} x2={projX} y2={y(z.top)} stroke={S.zone} strokeWidth={0.5} opacity={0.2} strokeDasharray="3,4" />
+            <line x1={ox2} y1={y(z.bot)} x2={projX} y2={y(z.bot)} stroke={S.zone} strokeWidth={0.5} opacity={0.2} strokeDasharray="3,4" />
+            <line x1={ox1 - 2} y1={y(z.top)} x2={ox1 - 2} y2={y(z.bot)} stroke={S.accent} strokeWidth={1} opacity={0.35} />
+            <text x={projX + 4} y={y(z.top) + 3} fill={S.accent} fontSize={7} {...mono} opacity={0.6}>{z.label}</text>
+            {z.note && <text x={projX + 4} y={y(z.top) + 12} fill={S.muted} fontSize={6} {...mono} opacity={0.4}>{z.note}</text>}
+            <text x={projX + 4} y={y(z.bot) - 2} fill={S.muted} fontSize={6} {...mono} opacity={0.4}>{z.top}–{z.bot}</text>
+          </g>
+        );
+      })}
+      {(levels || []).map((l, i) => (
+        <g key={`l${i}`}>
+          <line x1={p.l} y1={y(l.val)} x2={width - p.r} y2={y(l.val)} stroke={S.zone} strokeWidth={0.4} opacity={0.2} strokeDasharray={l.dash ? "2,4" : "none"} />
+          <text x={width - p.r + 4} y={y(l.val) + 3} fill={S.muted} fontSize={7} {...mono} opacity={0.4}>{l.label}</text>
+        </g>
+      ))}
+      {mode === "candles" ? (
+        candles.map(([o, h, l, c], i) => {
+          const bull = c >= o;
+          const cx = x(i);
+          return (
+            <g key={`c${i}`}>
+              <line x1={cx} y1={y(h)} x2={cx} y2={y(l)} stroke={S.wick} strokeWidth={0.6} opacity={0.5} />
+              <rect x={cx - bw / 2} y={y(Math.max(o, c))} width={bw} height={Math.max(0.5, Math.abs(y(o) - y(c)))} fill={bull ? S.bg : S.bear} stroke={bull ? S.bull : S.bear} strokeWidth={0.7} opacity={bull ? 0.8 : 0.6} />
+            </g>
+          );
+        })
+      ) : (
+        <polyline points={candles.map(([,,, c], i) => `${x(i)},${y(c)}`).join(" ")} fill="none" stroke={S.price} strokeWidth={1} opacity={0.6} strokeLinejoin="round" />
+      )}
+      {(fractals || []).map((f, i) => {
+        const cx = x(f.idx);
+        const isHigh = f.type === "high";
+        const cy = y(f.price) + (isHigh ? -8 : 10);
+        return (
+          <g key={`f${i}`}>
+            <text x={cx} y={cy} fill={S.accent} fontSize={7} textAnchor="middle" {...mono} opacity={0.5}>{isHigh ? "▽" : "△"}</text>
+            <text x={cx} y={cy + (isHigh ? -7 : 9)} fill={S.muted} fontSize={6} textAnchor="middle" {...mono} opacity={0.35}>{f.price}</text>
+          </g>
+        );
+      })}
+      {(() => {
+        const last = candles[candles.length - 1][3];
+        return (
+          <g>
+            <line x1={p.l} y1={y(last)} x2={width - p.r} y2={y(last)} stroke={S.price} strokeWidth={0.5} strokeDasharray="2,3" opacity={0.2} />
+            <rect x={width - p.r - 1} y={y(last) - 7} width={34} height={14} fill={S.price} rx={2} opacity={0.85} />
+            <text x={width - p.r + 16} y={y(last) + 3} fill={S.bg} fontSize={7} textAnchor="middle" fontWeight="bold" {...mono}>{last}</text>
+          </g>
+        );
+      })()}
+    </svg>
+  );
+}
+
+
+// DATA SECTION
+const TITLE = "ETHUSDT · H4";
+const candles = [
+  [
+    2120,
+    2144,
+    2096,
+    2105
+  ],
+  [
+    2105,
+    2164,
+    2094,
+    2138
+  ],
+  [
+    2138,
+    2143,
+    2068,
+    2087
+  ],
+  [
+    2087,
+    2094,
+    2055,
+    2074
+  ],
+  [
+    2074,
+    2099,
+    2070,
+    2073
+  ],
+  [
+    2073,
+    2093,
+    2062,
+    2084
+  ],
+  [
+    2084,
+    2088,
+    2059,
+    2083
+  ],
+  [
+    2083,
+    2083,
+    2046,
+    2051
+  ],
+  [
+    2051,
+    2062,
+    1966,
+    1978
+  ],
+  [
+    1978,
+    1993,
+    1956,
+    1984
+  ],
+  [
+    1984,
+    1990,
+    1969,
+    1979
+  ],
+  [
+    1979,
+    1996,
+    1972,
+    1980
+  ],
+  [
+    1980,
+    1984,
+    1964,
+    1983
+  ],
+  [
+    1983,
+    1995,
+    1975,
+    1989
+  ],
+  [
+    1989,
+    1991,
+    1970,
+    1981
+  ],
+  [
+    1981,
+    1983,
+    1948,
+    1955
+  ],
+  [
+    1955,
+    1974,
+    1955,
+    1970
+  ],
+  [
+    1970,
+    1977,
+    1936,
+    1948
+  ],
+  [
+    1948,
+    1960,
+    1930,
+    1955
+  ],
+  [
+    1955,
+    1980,
+    1945,
+    1951
+  ],
+  [
+    1951,
+    1955,
+    1925,
+    1943
+  ],
+  [
+    1943,
+    1971,
+    1928,
+    1965
+  ],
+  [
+    1965,
+    1972,
+    1916,
+    1937
+  ],
+  [
+    1937,
+    2006,
+    1930,
+    1977
+  ],
+  [
+    1977,
+    2014,
+    1963,
+    1984
+  ],
+  [
+    1984,
+    2022,
+    1979,
+    1992
+  ],
+  [
+    1992,
+    2033,
+    1992,
+    2023
+  ],
+  [
+    2023,
+    2039,
+    2006,
+    2012
+  ]
+];
+const zones = [
+  {
+    "originStart": 8,
+    "originEnd": 9,
+    "top": 1975,
+    "bot": 1963,
+    "label": "H4 FVG",
+    "note": "bull gap"
+  },
+  {
+    "originStart": 3,
+    "originEnd": 7,
+    "top": 2083,
+    "bot": 2055,
+    "label": "H4 FTA",
+    "note": "first target area"
+  },
+  {
+    "originStart": 20,
+    "originEnd": 22,
+    "top": 1937,
+    "bot": 1916,
+    "label": "H4 RB",
+    "note": "rejection block"
+  }
+];
+const levels = [
+  {
+    "val": 2199,
+    "label": "D1 Strong High",
+    "dash": true
+  },
+  {
+    "val": 1916,
+    "label": "H4 Strong Low",
+    "dash": false
+  },
+  {
+    "val": 2022,
+    "label": "H1 Last FH",
+    "dash": true
+  }
+];
+const fractals = [
+  {
+    "idx": 1,
+    "type": "high",
+    "price": 2164
+  },
+  {
+    "idx": 11,
+    "type": "high",
+    "price": 1996
+  },
+  {
+    "idx": 25,
+    "type": "high",
+    "price": 2022
+  },
+  {
+    "idx": 17,
+    "type": "low",
+    "price": 1936
+  },
+  {
+    "idx": 22,
+    "type": "low",
+    "price": 1916
+  }
+];
+
+// APP
+function App() {
+  const [mode, setMode] = useState("candles");
+  const S = useTheme();
+  return (
+    <div style={{ background: S.bg, minHeight: "100vh", padding: "24px 16px", ...mono, color: S.price }}>
+      <div style={{ maxWidth: 660, margin: "0 auto" }}>
+        <div style={{ display: "flex", gap: 4, marginBottom: 12 }}>
+          {["candles", "line"].map(m => (
+            <button key={m} onClick={() => setMode(m)} style={{
+              ...mono, fontSize: 10, padding: "4px 16px",
+              background: mode === m ? S.dimmer : "transparent",
+              color: mode === m ? S.price : S.muted,
+              border: `1px solid ${mode === m ? S.dim : S.dimmer}`,
+              borderRadius: 4, cursor: "pointer",
+            }}>{m}</button>
+          ))}
+        </div>
+        <Chart candles={candles} zones={zones} levels={levels} fractals={fractals} title={TITLE} mode={mode} />
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- TDA analysis (1M → W1 → D1 → H4 → H1) for ETHUSDT bullish reversal from W1 Fractal KL 1800
- Plan A: VC Entry at H4/H1 FVG 1963-1975, SL 1910, T1 2199 (3.9R), T2 2395 (7.2R)
- Plan B: Deeper accumulation at D1 FVG 1835-1870, SL 1790, T1 2199 (4.4R), T2 2395 (7.0R)
- Interactive D1 and H4 charts with zone origins + ASCII fallback

## Files
- `content/blog/ethusdt-w1-fractal-reversal-2395.md` — blog post (~1100 words, Ukrainian)
- `static/charts/ethusdt-w1-fractal-reversal-2395/d1.html` — D1 interactive chart
- `static/charts/ethusdt-w1-fractal-reversal-2395/h4.html` — H4 interactive chart
- `layouts/shortcodes/chart.html` — Hugo shortcode for chart embedding

Tracking issue: https://github.com/WhiteTRD/whitetrd-blog/issues/30

🤖 Generated with [Claude Code](https://claude.com/claude-code)